### PR TITLE
ZLCurlNetworkManager: Make it work with curl >= 7.62.0.

### DIFF
--- a/zlibrary/core/src/unix/curl/ZLCurlNetworkManager.cpp
+++ b/zlibrary/core/src/unix/curl/ZLCurlNetworkManager.cpp
@@ -285,9 +285,11 @@ std::string ZLCurlNetworkManager::perform(const ZLExecutionData::Vector &dataLis
 #endif
 					errors.insert(ZLStringUtil::printf(errorResource["peerFailedVerificationMessage"].value(), ZLNetworkUtil::hostFromUrl(url)));
 					break;
+#if CURLE_SSL_CACERT != CURLE_PEER_FAILED_VERIFICATION
 				case CURLE_SSL_CACERT:
 					errors.insert(ZLStringUtil::printf(errorResource["sslCertificateAuthorityMessage"].value(), ZLNetworkUtil::hostFromUrl(url)));
 					break;
+#endif
 				case CURLE_SSL_CACERT_BADFILE:
 					errors.insert(ZLStringUtil::printf(errorResource["sslBadCertificateFileMessage"].value(), request.sslCertificate().Path));
 					break;


### PR DESCRIPTION
curl >= 7.6.20 deprecated CURLE_SSL_CACERT in favor of CURLE_PEER_FAILED_VERIFICATION (see its changelog)